### PR TITLE
add config_param "level_field"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Using fluent-plugin-logdna, you can send the logs you collect with Fluentd to Lo
   mac C0:FF:EE:C0:FF:EE                    # replace with host mac address
   ip 127.0.0.1                             # replace with host ip address
   app my_app                               # replace with your app name
+  level_field severity                     # replace with field in record
 </match>
 ~~~~~
 * Restart fluentd to pick up the configuration changes.

--- a/lib/fluent/plugin/out_logdna.rb
+++ b/lib/fluent/plugin/out_logdna.rb
@@ -58,7 +58,7 @@ module Fluent
       line = {
         level: record[@level_field] || info,
         timestamp: time,
-        line: record['message'] || record.to_json
+        line: record.to_json
       }
       line[:app] = record['_app'] || record['app']
       line[:app] ||= @app if @app

--- a/lib/fluent/plugin/out_logdna.rb
+++ b/lib/fluent/plugin/out_logdna.rb
@@ -11,6 +11,7 @@ module Fluent
     config_param :mac, :string, default: nil
     config_param :ip, :string, default: nil
     config_param :app, :string, default: nil
+    config_param :level_field, :string, default: 'level'
 
     def configure(conf)
       super
@@ -55,7 +56,7 @@ module Fluent
 
     def gather_line_data(tag, time, record)
       line = {
-        level: record['level'] || record['severity'] || tag.split('.').last,
+        level: record[@level_field] || info,
         timestamp: time,
         line: record['message'] || record.to_json
       }


### PR DESCRIPTION
This patch makes to change 'level' field possible.
(#1 makes to use 'severity' only possible...)

And ...
Until now, if the record contains 'message', all other fields will be deleted.
I want to send all fields in record.