### PR TITLE
Do not append a element if line is empty

### DIFF
--- a/lib/fluent/plugin/out_logdna.rb
+++ b/lib/fluent/plugin/out_logdna.rb
@@ -51,7 +51,7 @@ module Fluent
 
       chunk.msgpack_each do |(tag, time, record)|
         line = gather_line_data(tag, time, record)
-        data << line
+        data << line unless line[:line].empty?
       end
 
       { lines: data }


### PR DESCRIPTION
If message is blank, it is not working.
example record) `{"message":""}`

Because logDNA dose not accept empty line.

```
$ curl "https://logs.logdna.com/logs/ingest?hostname=EXAMPLE_HOST&mac=C0:FF:EE:C0:FF:EE&ip=10.0.1.101&now=$(date +%s)" \
-u API_KEY: \
-H "Content-Type: application/json; charset=UTF-8" \
-d \
'{
   "lines": [
     {
       "timestamp": 1492558496,
       "line":"",
       "app":"myapp",
       "level": "INFO",
       "meta": {
         "customfield": {
           "nestedfield": "nestedvalue"
         }
       }
     }
   ]
}'
==>> {"error":"line field missing or not a string.","code":"BadRequest","status":"error"}
```

So, I add `unless line[:line].empty?`. 

Thanks.
