### PR TITLE
Switch to YAJL for better parsing resilience

### DIFF
--- a/fluent-plugin-logdna.gemspec
+++ b/fluent-plugin-logdna.gemspec
@@ -3,7 +3,7 @@ require 'date'
 
 Gem::Specification.new do |s|
   s.name        = 'fluent-plugin-logdna'
-  s.version     = '0.1.7'
+  s.version     = '0.1.8'
   s.date        = Date.today.to_s
   s.summary     = 'LogDNA plugin for Fluentd'
   s.description = 'Fluentd plugin for supplying output to LogDNA.'
@@ -19,4 +19,5 @@ Gem::Specification.new do |s|
   s.required_ruby_version = Gem::Requirement.new('>= 2.0.0')
   s.add_runtime_dependency 'fluentd', '>= 0.12.0', '< 2'
   s.add_runtime_dependency 'http', '~> 2.0', '>= 2.0.3'
+  s.add_runtime_dependency 'yajl-ruby', '~> 1.0'
 end

--- a/lib/fluent/plugin/out_logdna.rb
+++ b/lib/fluent/plugin/out_logdna.rb
@@ -20,7 +20,7 @@ module Fluent
 
     def start
       super
-      require 'json'
+      require 'yajl'
       require 'base64'
       require 'http'
       HTTP.default_options = { :keep_alive_timeout => 60 }
@@ -61,7 +61,7 @@ module Fluent
       line = {
         level: record['level'] || record['severity'] || tag.split('.').last,
         timestamp: time,
-        line: record['message'] || record.to_json
+        line: record['message'] || Yajl.dump(record)
       }
       line[:app] = record['_app'] || record['app']
       line[:app] ||= @app if @app


### PR DESCRIPTION
There is an issue with the typical ruby json module that causes the plugin to throw an exception when it's unable to convert data from ASCII to UTF8 or vice versa. 

YAJL is more resilient to these issues, and using it fixed a similar issue in my deployment, 