### PR TITLE
version conflict with previous yanked version

### DIFF
--- a/fluent-plugin-logdna.gemspec
+++ b/fluent-plugin-logdna.gemspec
@@ -3,7 +3,7 @@ require 'date'
 
 Gem::Specification.new do |s|
   s.name        = 'fluent-plugin-logdna'
-  s.version     = '0.2.0'
+  s.version     = '0.2.3'
   s.date        = Date.today.to_s
   s.summary     = 'LogDNA plugin for Fluentd'
   s.description = 'Fluentd plugin for supplying output to LogDNA.'


### PR DESCRIPTION
existing yanked versions: 0.2.0, 0.2.1, 0.2.2

https://rubygems.org/gems/fluent-plugin-logdna/versions