### PR TITLE
config: let user specify an alternate endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Using fluent-plugin-logdna, you can send the logs you collect with Fluentd to Lo
   - **Default**: `30 s`
 - `ingester_domain`: Custom Ingester URL, *Optional*
   - **Default**: `htttps://logs.logdna.com`
+- `ingester_endpoint`: Custom Ingester Endpoint, *Optional*
+  - **Default**: `/logs/ingest`
 
 ### Sample Configuration
 

--- a/lib/fluent/plugin/out_logdna.rb
+++ b/lib/fluent/plugin/out_logdna.rb
@@ -14,6 +14,7 @@ module Fluent
     config_param :app, :string, default: nil
     config_param :file, :string, default: nil
     config_param :ingester_domain, :string, default: 'https://logs.logdna.com'
+    config_param :ingester_endpoint, :string, default: '/logs/ingest'
     config_param :request_timeout, :string, default: '30'
 
     def configure(conf)
@@ -97,7 +98,7 @@ module Fluent
 
     def send_request(body)
       now = Time.now.to_i
-      url = "/logs/ingest?hostname=#{@host}&mac=#{@mac}&ip=#{@ip}&now=#{now}&tags=#{@tags}"
+      url = "#{@ingester_endpoint}?hostname=#{@host}&mac=#{@mac}&ip=#{@ip}&now=#{now}&tags=#{@tags}"
       @ingester.headers('apikey' => @api_key,
                         'content-type' => 'application/json')
                 .timeout(connect: @request_timeout, write: @request_timeout, read: @request_timeout)

--- a/test/plugin/test_out_logdna.rb
+++ b/test/plugin/test_out_logdna.rb
@@ -38,6 +38,7 @@ class LogdnaOutputTest < Test::Unit::TestCase
         # check defaults
         assert_equal 'https://logs.logdna.com', d.instance.ingester_domain
         assert_equal 30, d.instance.request_timeout
+        assert_equal '/logs/ingest', d.instance.ingester_endpoint
     end
 
     test 'instantiate the plugin and check setting config values' do
@@ -49,6 +50,7 @@ class LogdnaOutputTest < Test::Unit::TestCase
             ip 127.0.0.1
             tags  "my-tag"
             request_timeout 17s
+            ingester_endpoint this/is/my/alternate/endpoint
         ]
 
         d = create_driver(conf)
@@ -56,6 +58,7 @@ class LogdnaOutputTest < Test::Unit::TestCase
         # check set config values
         assert_equal 'my-tag', d.instance.tags
         assert_equal 17, d.instance.request_timeout
+        assert_equal 'this/is/my/alternate/endpoint', d.instance.ingester_endpoint
     end
 
     test 'instantiate the plugin with ms request_timeout value' do


### PR DESCRIPTION
Refer to the description of the issue https://github.com/logdna/fluent-plugin-logdna/issues/31 for details about why this change is needed.

Please review and merge.