### PR TITLE
docs: update invalid link to working link

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ sudo dpkg -i fluent-plugin-logdna*.deb
 
 ## Additional Options
 
-For advanced configuration options, please refer to the [buffered output parameters documentation.] (https://docs.fluentd.org/v/0.12/output#buffered-output-parameters)
+For advanced configuration options, please refer to the [buffered output parameters documentation.](https://docs.fluentd.org/v/0.12/output#buffered-output-parameters)
 
 Questions or concerns? Contact [support@logdna.com](mailto:support@logdna.com).
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ sudo dpkg -i fluent-plugin-logdna*.deb
 
 ## Additional Options
 
-For advanced configuration options, please refer to the [buffered output parameters documentation.](http://docs.fluentd.org/articles/output-plugin-overview#buffered-output-parameters)
+For advanced configuration options, please refer to the [buffered output parameters documentation.] (https://docs.fluentd.org/v/0.12/output#buffered-output-parameters)
 
 Questions or concerns? Contact [support@logdna.com](mailto:support@logdna.com).
 


### PR DESCRIPTION
http://docs.fluentd.org/articles/output-plugin-overview#buffered-output-parameters link is no longer available.  replacing with https://docs.fluentd.org/v/0.12/output#buffered-output-parameters